### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,6 +41,7 @@ Depends: libnfnetlink0 (= ${binary:Version}),
          ${misc:Depends},
          ${misc:Pre-Depends},
          ${shlibs:Depends}
+Multi-Arch: same
 Description: Development files for libnfnetlink0
  libnfnetlink is the low-level library for netfilter related
  kernel/userspace communication. It provides a generic messaging


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/libnfnetlink/3533cb72-45ba-47ba-8053-5f0fce21c18c.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/18/361b17bdccf7d0e4fce10a0a6ea918549492e2.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/32/be3f138094d7a1e69ca67144aff57219f3736d.debug
### Control files of package libnfnetlink-dev: lines which differ (wdiff format)
* {+Multi-Arch: same+}

No differences were encountered between the control files of package \*\*libnfnetlink0\*\*
### Control files of package libnfnetlink0-dbg: lines which differ (wdiff format)
* Build-Ids: [-32be3f138094d7a1e69ca67144aff57219f3736d-] {+18361b17bdccf7d0e4fce10a0a6ea918549492e2+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/3533cb72-45ba-47ba-8053-5f0fce21c18c/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/3533cb72-45ba-47ba-8053-5f0fce21c18c/diffoscope)).
