### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,6 @@ Description: Netfilter netlink library
 Package: libnfnetlink0-dbg
 Section: debug
 Architecture: any
-Pre-Depends: dpkg (>= 1.17.5)
 Depends: libnfnetlink0 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}
 Description: Debugging symbols for libnfnetlink0
  libnfnetlink is the low-level library for netfilter related

--- a/debian/libnfnetlink0-dbg.maintscript
+++ b/debian/libnfnetlink0-dbg.maintscript
@@ -1,1 +1,0 @@
-symlink_to_dir /usr/share/doc/libnfnetlink0-dbg /usr/share/doc/libnfnetlink0 1.0.1-2~ libnfnetlink0-dbg


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/libnfnetlink/e719bd72-1411-472a-a39c-beebf01d0033.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in first set of .debs but not in second
    -rwxr-xr-x  root/root   DEBIAN/postinst
    -rwxr-xr-x  root/root   DEBIAN/postrm
    -rwxr-xr-x  root/root   DEBIAN/preinst
    -rwxr-xr-x  root/root   DEBIAN/prerm

No differences were encountered between the control files of package \*\*libnfnetlink-dev\*\*

No differences were encountered between the control files of package \*\*libnfnetlink0\*\*
### Control files of package libnfnetlink0-dbg: lines which differ (wdiff format)
* [-Pre-Depends: dpkg (>= 1.17.5)-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/e719bd72-1411-472a-a39c-beebf01d0033/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/e719bd72-1411-472a-a39c-beebf01d0033/diffoscope)).
